### PR TITLE
Removed the title column from the comments table

### DIFF
--- a/db/migrate/20210824032928_remove_title_from_comments.rb
+++ b/db/migrate/20210824032928_remove_title_from_comments.rb
@@ -1,0 +1,5 @@
+class RemoveTitleFromComments < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :comments, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_23_094203) do
+ActiveRecord::Schema.define(version: 2021_08_24_032928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "comments", force: :cascade do |t|
-    t.string "title"
     t.text "content"
     t.bigint "user_id", null: false
     t.bigint "message_id", null: false


### PR DESCRIPTION
I removed the title column, but this will break the seeds when we added the comments. Since the branch that is adding the comments to the seed has no been pulled yet, when you merge this, make sure to let me know, so I can work on refactoring the seed file.
Closes #14 