### PR TITLE
reduced the font size on mobile on the landing page

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -29,7 +29,13 @@
 		display: inline-block;
 	}
 }
-
+@media (min-width: 100px) and (max-width: 575px) {
+  .wrapper {
+    h1 {
+      font-size: 60px;
+    }
+  }
+}
 @keyframes textclip {
 	to {
 		background-position: 200% center;


### PR DESCRIPTION
Changed the font size of the renRAKU title on the landing page, because I realized on mobile it was breaking the layout.

Before
![image](https://user-images.githubusercontent.com/18255733/130797089-9d9612fe-d161-4865-89a7-89351b053631.png)

After
![image](https://user-images.githubusercontent.com/18255733/130797010-0e2731ec-dc9f-4934-8a49-185b167444d5.png)
