### PR TITLE
cards change to column before breaking

### DIFF
--- a/app/assets/stylesheets/components/_split_container.scss
+++ b/app/assets/stylesheets/components/_split_container.scss
@@ -2,7 +2,7 @@
     border-radius: 16px;
     margin: 16px;
   }
-@media (max-width: 900px) {
+@media (max-width: 1000px) {
   .container-fluid {
     flex-direction: column;
   }


### PR DESCRIPTION
closes #71 

When screen is smaller, cards change to column before they break
![image](https://user-images.githubusercontent.com/18255733/131078102-30edf477-f95c-4c81-abd0-7e89bdc6b090.png)

![image](https://user-images.githubusercontent.com/18255733/131078131-18903874-97fd-4b1e-9723-f729467f4319.png)
