### PR TITLE
Class buttons

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -91,7 +91,7 @@
   border-radius: 8px;
 }
 .tag-selector:checked + label {
-  background-color: $blue;
+  background-color: $green;
   color: white;
   padding: 10px 20px 10px 20px;
   box-shadow: 2px 2px 2px 2px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
Made the button gray when not selected and green when class is selected. Style matches other buttons on the app too.
![image](https://user-images.githubusercontent.com/18255733/131092957-43d0ddf6-1526-49fb-aebb-b8f11655544c.png)
