### PR TITLE
Event card collapse

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -128,6 +128,7 @@ figure {
 
 .event-card {
 	border: 2px solid $dark-electric-blue;
+  position: relative;
 	border-radius: 8px;
 	overflow: hidden;
   background-color: white;
@@ -183,6 +184,20 @@ figure {
 			margin-right: 6px;
 		}
 	}
+}
+// Will put the "see classes" button on top right corner of the card
+#see-classes {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 8px;
+  background-color: $blue;
+  color: white;
+  text-decoration: none;
+  border-end-start-radius: 8px;
+  &:hover {
+    background-color: lighten($blue, 5%);
+  }
 }
 // For the category cards on the homepage
 .card-category {

--- a/app/views/events/_events_card.html.erb
+++ b/app/views/events/_events_card.html.erb
@@ -15,6 +15,7 @@
 
             <p class="event-card-desc"><%= event.rich_body %></p>
 
+            <% if event.kurasus.length < 3 %>
             <div class="d-flex justify-content-start">
               <span class="event-card-classes">
               For the following classes:
@@ -25,6 +26,22 @@
                 <% end %>
               </span>
             </div>
+            <% else %>
+              <a class="btn btn-primary" data-toggle="collapse" href="#event<%= event.id %>" role="button" aria-expanded="false" aria-controls="collapseExample">
+                See Classes
+              </a>
+            <div class="collapse" id="event<%= event.id %>">
+              <div class="d-flex justify-content-start">
+              <span class="event-card-classes">
+                <% event.kurasus.each do |kurasu|%>
+                  <div class="classes">
+                    <%= kurasu.name %>
+                  </div>
+                <% end %>
+              </span>
+            </div>
+            </div>
+            <% end %>
             <div class="d-flex justify-content-end">
               <span>
                 <%= link_to 'Update Event', edit_event_path(event), class: "btn btn-danger mx-1" if @user.teacher %>

--- a/app/views/events/_events_card.html.erb
+++ b/app/views/events/_events_card.html.erb
@@ -27,19 +27,23 @@
               </span>
             </div>
             <% else %>
-              <a class="btn btn-primary" data-toggle="collapse" href="#event<%= event.id %>" role="button" aria-expanded="false" aria-controls="collapseExample">
-                See Classes
-              </a>
-            <div class="collapse" id="event<%= event.id %>">
-              <div class="d-flex justify-content-start">
-              <span class="event-card-classes">
-                <% event.kurasus.each do |kurasu|%>
-                  <div class="classes">
-                    <%= kurasu.name %>
-                  </div>
-                <% end %>
-              </span>
-            </div>
+            <div class="d-flex">
+              <div>
+                <a id="see-classes" data-toggle="collapse" href="#event<%= event.id %>" role="button" aria-expanded="false" aria-controls="collapseExample">
+                  See Classes
+                </a>
+              </div>
+              <div class="collapse" id="event<%= event.id %>">
+                <div class="d-flex justify-content-start">
+                <span class="event-card-classes">
+                  <% event.kurasus.each do |kurasu|%>
+                    <div class="classes">
+                      <%= kurasu.name %>
+                    </div>
+                  <% end %>
+                </span>
+              </div>
+              </div>
             </div>
             <% end %>
             <div class="d-flex justify-content-end">


### PR DESCRIPTION
When event cards have more than 2 classes (this number can be changed later, but for now it was the best way to display the result since I only have access to 4 classes total), then the class list will be hidden and only showed upon clicking on "see classes" button.
![image](https://user-images.githubusercontent.com/18255733/131277743-c504a429-602f-4fd1-ae7c-75d146646997.png)

After clicking the button
![image](https://user-images.githubusercontent.com/18255733/131277771-01112d28-1e0d-46df-809f-29c4c1c0a4ef.png)
