### PR TITLE
Changed the description typo for parent-teacher meetings card on dash…

### DIFF
--- a/app/views/dashboards/_teacher_cards.html.erb
+++ b/app/views/dashboards/_teacher_cards.html.erb
@@ -29,7 +29,7 @@
         <h3 class="text-center">
           <i class="fas fa-chevron-up"></i>
         </h3 class="text-center">
-        <p>Schedule parent-teacher meetings for each students in the class you are in charge of.<br>
+        <p>Schedule parent-teacher meetings for each student in the class you are in charge of.<br>
           &nbsp;</p>
         <button class="btn btn-primary">
           Schedule meetings

--- a/app/views/dashboards/_teacher_cards.html.erb
+++ b/app/views/dashboards/_teacher_cards.html.erb
@@ -11,7 +11,6 @@
         <%= link_to "Go to the board", events_path, class: 'btn btn-primary' %>
       </figcaption>
     </figure>
-
     <figure class="image-block mx-2">
       <h1>Notebook</h1>
       <img src="<%= image_path 'dashboard/notebook.jpg' %>" alt="" />
@@ -23,7 +22,6 @@
         <%= link_to "Go to the notebook", kurasus_path, class: 'btn btn-primary' %>
       </figcaption>
     </figure>
-
     <figure class="image-block mx-2">
       <h1>Parent meetings</h1>
       <img src="<%= image_path 'dashboard/meeting.jpg' %>" alt="" />
@@ -31,13 +29,13 @@
         <h3 class="text-center">
           <i class="fas fa-chevron-up"></i>
         </h3 class="text-center">
-        <p>Schedule pa<i class="fas fa-chevron-up"></i>her meetings for each students in the class you are in charge of.<br>&nbsp;</p>
+        <p>Schedule parent-teacher meetings for each students in the class you are in charge of.<br>
+          &nbsp;</p>
         <button class="btn btn-primary">
           Schedule meetings
         </button>
       </figcaption>
     </figure>
-
     <figure class="image-block mx-2">
       <h1>Class schedules</h1>
       <img src="<%= image_path 'dashboard/schedule.jpg' %>" alt="" />
@@ -51,7 +49,6 @@
         </button>
       </figcaption>
     </figure>
-
     <figure class="image-block mx-2">
       <h1>Grades</h1>
       <img src="<%= image_path 'dashboard/grade.jpg' %>" alt="" />


### PR DESCRIPTION
The typo on the description for the p/t meeting card is fixed
<img width="344" alt="Screen Shot 2021-08-30 at 14 07 17" src="https://user-images.githubusercontent.com/84015779/131288095-9935607d-9cd3-4a5c-a12a-812aa197a96c.png">
