### PR TITLE
notebook button redirects to proper student

### DIFF
--- a/app/views/kurasus/_kurasu_display.html.erb
+++ b/app/views/kurasus/_kurasu_display.html.erb
@@ -11,7 +11,7 @@
       <div class="card my-4" id="student-card">
           <div class="flex-column justify-content-between">
             <div class="notebook-button">
-              <a href="#" class="btn btn-primary">Notebook</a>
+              <a href="/students/<%= student.student_number %>/messages" class="btn btn-primary">Notebook</a>
             </div>
             <div class="grades-button">
               <a href="#" class="btn btn-danger">Grades</a>


### PR DESCRIPTION
Upon changing the layout of the student card, I forgot to include the link to redirect to the student's notebook. Fixed it now.