### PR TITLE
Remove parent meetings card from teachers dashboard

### DIFF
--- a/app/views/dashboards/_teacher_cards.html.erb
+++ b/app/views/dashboards/_teacher_cards.html.erb
@@ -1,7 +1,8 @@
 <div class="d-flex justify-content-between dashboard-layout">
   <div class="flex-column ml-3 mt-3">
     <div id="dashboard-profile" class="text-center">
-      <h3>Welcome<br> <%= current_user.name %></h3>
+      <h3>Welcome<br>
+         <%= current_user.name %></h3>
       <p>Today is <em><%= Date.today.strftime("%A, %b %d") %></em></p>
       <p class="time"><%= Time.now.strftime("%H:%M") %></p>
       <p>You are in charge of <strong><%= current_user.kurasus.length %></strong> classes</p>
@@ -20,7 +21,6 @@
           <%= link_to "Go to the board", events_path, class: 'btn btn-primary' %>
         </figcaption>
       </figure>
-
       <figure class="image-block mx-2">
         <h1>Classes</h1>
         <img src="<%= image_path 'dashboard/class.png' %>" alt="" />
@@ -28,23 +28,10 @@
           <h3 class="text-center">
             <i class="fas fa-chevron-up"></i>
           </h3>
-          <p>Write a message in a student's notebook<br>Check the class schedules<br>Look at students' grades</p>
+          <p>Write a message in a student's notebook<br>
+            Check the class schedules<br>
+            Look at students' grades</p>
           <%= link_to "Go to the classes", kurasus_path, class: 'btn btn-primary' %>
-        </figcaption>
-      </figure>
-
-      <figure class="image-block mx-2">
-        <h1>Parent meetings</h1>
-        <img src="<%= image_path 'dashboard/meeting.jpg' %>" alt="" />
-        <figcaption>
-          <h3 class="text-center">
-            <i class="fas fa-chevron-up"></i>
-          </h3 class="text-center">
-          <p>Schedule parent-teacher meetings for each student in the class you are in charge of.<br>
-          &nbsp;</p>
-          <button class="btn btn-primary">
-            Schedule meetings
-          </button>
         </figcaption>
       </figure>
     </div>


### PR DESCRIPTION
Removes parent metings card from teacher dashboard. As of now the parent dashboard is still unchanged)

<img width="1440" alt="Screen Shot 2021-09-01 at 18 03 11" src="https://user-images.githubusercontent.com/69414602/131644361-ed8c86ed-136f-4f07-9584-76db20eeda13.png">
