### PR TITLE
Notifications on students

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -346,10 +346,11 @@ figure {
   bottom: 50px;
   right: -12px;
   margin-right: 4px;
-  padding-right: 4px;
-  padding-left: 4px;
+  padding-right: 13px;
+  padding-left: 13px;
   background-color: $red;
-  border-radius: 10px;
+  border-radius: 50%;
+  font-size: x-large;
 }
 // For the animated cards on the homepage
 .page-contain {

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,6 +1,7 @@
 class Student < ApplicationRecord
   has_many :events, through: :participants
   has_many :messages
+  has_many :comments, through: :messages
   has_many :grades, dependent: :destroy
   belongs_to :kurasu
   belongs_to :user
@@ -8,4 +9,7 @@ class Student < ApplicationRecord
   validates :last_name, presence: true
   validates :birthday, presence: true
   validates :student_number, presence: true
+  def unread_comments
+    comments.where(status: "unread").count
+  end
 end

--- a/app/views/kurasus/_kurasu_display.html.erb
+++ b/app/views/kurasus/_kurasu_display.html.erb
@@ -22,7 +22,9 @@
             </div>
             <div class="card-body d-flex justify-content-between">
               <p class="card-text stretched-link pr-4"><%= student.first_name%> <%= student.last_name%></p>
-              <p id="student-number">#<%= student.student_number %></p>
+              <% unless student.unread_comments.zero? %>
+                <p id="student-number"><%= student.unread_comments %></p>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/messages/_discussion.html.erb
+++ b/app/views/messages/_discussion.html.erb
@@ -17,9 +17,11 @@
                 Add Comment <i class="fas fa-sort-down"></i>
               <% end %>
             <% end %>
-            <div class="notification-pill" id="notif-comment-<%= message.id %>">
-              <%= message.comments.where(status: "unread").count %>
-            </div>
+            <% if false %>
+              <div class="notification-pill" id="notif-comment-<%= message.id %>">
+                <%= message.comments.where(status: "unread").count %>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>
@@ -30,7 +32,7 @@
       <%= render comment %>
     <% end %>
     <div id="comment<%= message.id %>-placeholder"></div>
-    <div class="card mt-4 comment-form" id="<%= current_user.teacher ? "teacher-comment": "parents-comment" %>">
+    <div class="card mt-4" id="<%= current_user.teacher ? "teacher-comment": "parents-comment" %>">
       <div class="card-body">
         <div class="d-flex flex-column <%= "text-right" unless current_user.teacher %>">
           <%= render 'comments/form', message: message, comment: @comment %>


### PR DESCRIPTION
New comments are shown on kurasus page as a pill next to students. Replaces the student number. No pill is shown when there are no new comments.

<img width="1440" alt="Screen Shot 2021-09-02 at 16 49 00" src="https://user-images.githubusercontent.com/69414602/131804133-716eb9af-3349-46e9-b5bb-200a7dcacd47.png">
