### PR TITLE
card has padding on mobile

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -233,6 +233,10 @@ figure {
     font-size: 2em;
     color: white;
   }
+  @media (max-width: 756px) {
+    padding-top: 20px;
+    padding-bottom: 20px;
+  }
 }
 .schedule-button {
   background-color: rgb(235,235,235);


### PR DESCRIPTION
Class cards on mobile have padding, so if the class name is longer, it won't conflict with the buttons.
Before 
![image](https://user-images.githubusercontent.com/18255733/132146309-ac6148fb-c9c3-4c2e-bf07-30d3b75b36d2.png)
After
![image](https://user-images.githubusercontent.com/18255733/132146325-aaef5db1-5978-4f26-b0af-6d3a1ece36c3.png)
Closes #236 
